### PR TITLE
Update TSRCollector.ps1

### DIFF
--- a/TSRCollector.ps1
+++ b/TSRCollector.ps1
@@ -22,7 +22,7 @@ Function EndScript{
 $DateTime=Get-Date -Format yyyyMMdd_HHmmss
 Start-Transcript -NoClobber -Path "C:\programdata\Dell\TSRCollector\TSRCollector_$DateTime.log"
 $text=@"
-v1.7
+v1.71
   _____ ___ ___    ___     _ _        _           
  |_   _/ __| _ \  / __|___| | |___ __| |_ ___ _ _ 
    | | \__ \   / | (__/ _ \ | / -_) _|  _/ _ \ '_|
@@ -65,13 +65,17 @@ $credential = New-Object System.Management.Automation.PSCredential($user, $secpa
         $NSLookupAll+=$item
     }
     $ShareIP=(($NSLookupAll -split 'Name:    ')[-1] -split 'Address:  ')[-1]
+    IF($ShareIP -notmatch "^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}$") {
+        $ShareIP=(($NSLookupAll -split 'Name:    ')[-1] -split 'Addresses:  ')[-1]
+        $ShareIP=($ShareIP -split "	  ")[-1]
+    }
     Write-Host "    Host IP: $ShareIP"
 # Create a new folder and shares it
     Write-Host "Creating a new shared folder to save the TSRs..."
     $ShareName = "Logs"
     $ShareFolder=$MyTemp+"\"+$ShareName
     New-Item -ItemType Directory -Force -Path $ShareFolder  >$null 2>&1
-    New-SmbShare -Name "Logs" -Path "$ShareFolder" -Temporary -FullAccess Everyone  >$null 2>&1
+    New-SmbShare -Name "Logs" -Path "$ShareFolder" -Temporary -FullAccess (([System.Security.Principal.SecurityIdentifier]("S-1-1-0")).Translate([System.Security.Principal.NTAccount])) >$null 2>&1
     Write-Host "    Share location is $ShareFolder"
 # Gets the logged on creds
     Write-Host "Gathering the credentials to access the share..."
@@ -162,16 +166,28 @@ IF($iDRACIPCheck -imatch "n"){
             ($result.Content| ConvertFrom-Json).'@Message.ExtendedInfo'
         }
         Catch{
-            IF(($RespErr.message| ConvertFrom-Json).error.'@Message.ExtendedInfo'.message -match 'already running'){
+            $RespErrMessage=$null
+            Try {$RespErrMessage=($RespErr.message| ConvertFrom-Json).error.'@Message.ExtendedInfo'.message} catch {}
+            IF($RespErrMessage -match 'already running'){
                 Write-Host "    ERROR: A SupportAssist job is already running on the server. Please try again later." -ForegroundColor Red
-            }ElseIF(($RespErr.message| ConvertFrom-Json).error.'@Message.ExtendedInfo'.message -imatch 'The authentication credentials included with this request are missing or invalid.'){
+            } ElseIF($RespErrMessage -match 'The authentication credentials included with this request are missing or invalid.' -or $RespErr.Message -eq "The remote server returned an error: (401) Unauthorized."){
                 $credential=Get-Credential -Message "Please enter the iDRAC Adminitrator credentials for $idrac_ip"
                 $result= Invoke-WebRequest -UseBasicParsing -Uri $URI -Credential $credential -Method POST -Headers @{'content-type'='application/json';'Accept'='application/json'} -Body $body -ErrorVariable RespErr
+                ($result.Content| ConvertFrom-Json).'@Message.ExtendedInfo'
             }
         }
-    IF($result.StatusCode -eq 202){Write-Host "    StatusCode:"$result.StatusCode "Successfully scheduled TSR" -ForegroundColor Green }Else{Write-Host "    ERROR: StatusCode:" $result.StatusCode "Failed to scheduled TSR" -ForegroundColor Red}
+    IF($RespErrMessage -match "Unable to run the method because the requested HTTP method is not allowed.") {
+        Write-Warning "Idrac8 Detected. Using racadm"
+        try {
+            $tag=(racadm -r $idrac_ip -u "$($credential.UserName)" -p "$($credential.GetNetworkCredential().Password)" getsysinfo | findstr Service).substring(26)
+            racadm -r $idrac_ip -u "$($credential.UserName)" -p "$($credential.GetNetworkCredential().Password)" techsupreport export -f "$ShareFolder\TSR$(get-date -Format 'yyyyMMddHHmmss')_$tag.zip"
+            $result = @([pscustomobject]@{statuscode=202})
+        } catch {Write-host -ForegroundColor Red "ERROR: Racadm failed. racadm may be missing"}
     }
-    Write-Host "Please wait while TSRs are collected. Ussually this takes 2-5 minutes per node."
+    IF($result.StatusCode -eq 202){Write-Host "    StatusCode:"$result.StatusCode "Successfully scheduled TSR" }Else{Write-Host "    ERROR: StatusCode:" $result.StatusCode "Failed to scheduled TSR" -ForegroundColor Red}
+    }
+    Write-Host "Please wait while TSRs are collected. Usually this takes 2-5 minutes per node." -ForegroundColor Green
+    Write-Host "TSRs will be saved at $ShareFolder" -ForegroundColor Green
     IF(!($LeaveShare -eq $True)){
         # Creating Scheduled Job to remove SMB share in 10 mins
             Write-Host "Creating Scheduled Job to remove SMB share in 15 mins..."
@@ -183,8 +199,8 @@ IF($iDRACIPCheck -imatch "n"){
                     Remove-SmbShare -Name "Logs" -Force
             }
         # Change directory to the shared folder were the TSRs will be put
-            cd $ShareFolder
-            Invoke-Expression "explorer ."
+			try {explorer "$ShareFolder" } catch {
+			Start-Process -FilePath "cmd.exe" -ArgumentList("/K","cd","/d","$ShareFolder","&","echo TSRs will show up in this directory when finished") }
     }
 } #End ShouldProcess
 Stop-Transcript


### PR DESCRIPTION
- Fixed an issue if more than one IP is registered in DNS for a node.
- Made the share path permissions language agnostic as suggested by a German customer.
- Created a new section for iDrac8 systems to use racadm for TSR collection as they do not support Redfish TSR collection.
- Message colored in green for the path of the log files appears near the bottom of the ouput to find it easier.
- For Core systems, since they do not have Explorer, a cmd prompt will appear with the path of the log files.
- Changed wait time for share deletion to 15 minutes for some slower collections